### PR TITLE
Enforce trailing slash on router level through middleware

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -56,7 +56,7 @@ module.exports = {
   },
 
   router: {
-    middleware: ['meta-canonical'],
+    middleware: ['enforce-trailing-slash', 'meta-canonical'],
   },
 
   modules: [

--- a/src/client/components/app-header/app-header.vue
+++ b/src/client/components/app-header/app-header.vue
@@ -8,7 +8,7 @@
       <h2 class="a11y-sr-only">{{ menu.title }}</h2>
       <ul class="inline-list">
         <li v-for="item in menu.items" :key="item.slug">
-          <nuxt-link :to="localePath({ name: 'slug', params: { slug: item.slug } }) + '/'"
+          <nuxt-link :to="localePath({ name: 'slug', params: { slug: item.slug } })"
             class="app-header__menu-link"
           >
             {{ item.title }}

--- a/src/client/components/language-selector/language-selector.vue
+++ b/src/client/components/language-selector/language-selector.vue
@@ -4,13 +4,13 @@
       <nuxt-link v-if="isSlugRoute"
         rel="alternate"
         :hreflang="locale.code"
-        :to="localePath({ name: 'slug', params: { slug: slugI18n[locale.code] } }, locale.code) + '/'">
+        :to="localePath({ name: 'slug', params: { slug: slugI18n[locale.code] } }, locale.code)">
         {{ locale.name }}
       </nuxt-link>
       <nuxt-link v-else
         rel="alternate"
         :hreflang="locale.code"
-        :to="switchLocalePath(locale.code) + '/'">
+        :to="switchLocalePath(locale.code)">
         {{ locale.name }}
       </nuxt-link>
     </li>

--- a/src/client/middleware/enforce-trailing-slash.js
+++ b/src/client/middleware/enforce-trailing-slash.js
@@ -1,0 +1,5 @@
+export default function ({ route, redirect }) {
+  if (!route.fullPath.endsWith('/')) {
+    redirect(301, `${route.fullPath}/`)
+  }
+}

--- a/src/client/middleware/meta-canonical.js
+++ b/src/client/middleware/meta-canonical.js
@@ -1,13 +1,9 @@
-export default function (context) {
-  const link = context.app.head.link.find(item => item.rel === 'canonical')
-  const url = enforceTrailingSlash(`${context.env.baseUrl}${context.route.path}`)
+export default function ({ app, env, route }) {
+  const link = app.head.link.find(item => item.rel === 'canonical')
+  const url = `${env.baseUrl}${route.path}`
   if (link) {
     link.href = url
   } else {
-    context.app.head.link.push({ rel: 'canonical', href: url })
+    app.head.link.push({ rel: 'canonical', href: url })
   }
-}
-
-function enforceTrailingSlash (url) {
-  return (url.endsWith('/')) ? url : `${url}/`
 }


### PR DESCRIPTION
This prevents need to add a trailing slash on each route manually, which was error prone.

This also ensures manually entered URLs without a trailing slash, etc, are redirected to a URL with a trailing slash.

Resolves [Trello issue 36: enforce trailing slash](https://trello.com/c/4KQdh52w/36-enforce-trailing-slash).