### PR TITLE
Configure Google Analytics

### DIFF
--- a/dato.config.js
+++ b/dato.config.js
@@ -14,6 +14,7 @@ module.exports = (dato, root, i18n) => {
 
   fs.writeFileSync(`${__dirname}/${staticDir}/_redirects`, redirectsToText(dato.redirects), 'utf8')
 
+  root.createDataFile(`${dataDir}/app.json`, 'json', appSettingsToJson(dato.app))
   root.createDataFile(`${dataDir}/locales.json`, 'json', locales)
   root.createDataFile(`${dataDir}/menu.json`, 'json', menuToJson(dato, i18n))
   root.createDataFile(`${dataDir}/pages.json`, 'json', pageSlugMap(dato, i18n))
@@ -25,6 +26,10 @@ module.exports = (dato, root, i18n) => {
     })
     root.createDataFile(`${dataDir}/${locale}/messages.json`, 'json', translationsToJson(dato.translations))
   })
+}
+
+function appSettingsToJson(app) {
+  return pick(app, ['title', 'googleAnalyticsTrackingId'])
 }
 
 /**

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 const flattenDeep = require('lodash/flattenDeep')
 
+const appConfig = require('./src/client/static/data/app.json')
 const locales = require('./src/client/static/data/locales.json')
 const pages = require('./src/client/static/data/pages.json')
 
@@ -34,7 +35,7 @@ module.exports = {
   ** Headers of the page
   */
   head: {
-    title: 'Lean Web Kit',
+    title: appConfig.title,
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
@@ -63,7 +64,7 @@ module.exports = {
   modules: [
     '@nuxtjs/proxy',
     ['@nuxtjs/google-analytics', { // https://github.com/nuxt-community/analytics-module
-      id: 'UA-47742430-3',
+      id: appConfig.googleAnalyticsTrackingId,
       /**
        * Debug while in development mode
        * @see https://matteogabriele.gitbooks.io/vue-analytics/content/docs/debug.html

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,11 +5,12 @@ const pages = require('./src/client/static/data/pages.json')
 
 /**
  * Use Netlify's URL variable:
- * https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
+ * @see https://www.netlify.com/docs/continuous-deployment/#build-environment-variables
  */
-const baseUrl = process.env.URL || ''
+const { NODE_ENV, URL } = process.env
+const baseUrl = URL || ''
 const defaultLocale = locales[0]
-const isProduction = (process.env.NODE_ENV === 'production')
+const isProduction = (NODE_ENV === 'production')
 
 module.exports = {
   srcDir: 'src/client/',
@@ -61,6 +62,25 @@ module.exports = {
 
   modules: [
     '@nuxtjs/proxy',
+    ['@nuxtjs/google-analytics', { // https://github.com/nuxt-community/analytics-module
+      id: 'UA-47742430-3',
+      /**
+       * Debug while in development mode
+       * @see https://matteogabriele.gitbooks.io/vue-analytics/content/docs/debug.html
+       */
+      debug: {
+        enabled: !isProduction,
+        sendHitTask: isProduction,
+      },
+      /**
+       * Anonymize tracking
+       * @see https://www.themarketingtechnologist.co/setting-up-a-cookie-law-compliant-google-analytics-tracker/
+       */
+      set: [
+        { field: 'displayFeaturesTask', value: null },
+        { field: 'anonymizeIp', value: true },
+      ],
+    }],
     ['nuxt-i18n', {
       defaultLocale,
       detectBrowserLanguage: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,14 @@
         }
       }
     },
+    "@nuxtjs/google-analytics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/google-analytics/-/google-analytics-2.0.2.tgz",
+      "integrity": "sha512-NpDQI7w4jr93Ukh98n3d0BRDHhX7cDUi3W2E0CAU6t5wmC+Q6cwQMqcEl32tGJBQlPZYWSrBKIM0A413HpL3TA==",
+      "requires": {
+        "vue-analytics": "^5.4.0"
+      }
+    },
     "@nuxtjs/proxy": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-1.2.4.tgz",
@@ -13855,6 +13863,11 @@
       "version": "2.5.16",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
       "integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ=="
+    },
+    "vue-analytics": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.12.2.tgz",
+      "integrity": "sha1-Yxi+PPoM5/prAMuKn81CJo51+rg="
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start:dist": "http-server './dist/client/' -c-1 -o -p 5326 --proxy 'http://localhost:9000/'"
   },
   "dependencies": {
+    "@nuxtjs/google-analytics": "2.0.2",
     "@nuxtjs/proxy": "1.2.4",
     "dotenv": "6.0.0",
     "dotenv-safe": "6.0.0",


### PR DESCRIPTION
... for basic anonymous tracking.

Resolves [Trello issue 2: Configure Google Analytics](https://trello.com/c/SHn1B8He/2-configure-google-analytics).

The easiest way to test this feature is by checking out the branch locally and navigating the site locally with DevTools open. In development mode all tracking events are logged to the console and are not sent to the server. @brunadafonseca @sveroude you've also been given access to the Analytics dashboard, so you could also check that in combination with the deploy on Netlify.