### PR TITLE
Remove images from rich text

### DIFF
--- a/dato.config.js
+++ b/dato.config.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const cheerio = require('cheerio')
 const dotenv = require('dotenv-safe')
 const { pick, omit } = require('lodash')
 const slugify = require('slugify')
@@ -55,6 +56,15 @@ function pageSlugMap (dato, i18n) {
   }, {})
 }
 
+function transformItem(item) {
+  if (item.type === 'text') {
+    const $ = cheerio.load(item.body)
+    $('img').remove()
+    item.body = $('body').html()
+  }
+  return item
+}
+
 function pageToJson (page, i18n) {
   const { title, slug, hasToc } = page
   const sections = page.sections.map(({ title, items }) => ({
@@ -63,6 +73,7 @@ function pageToJson (page, i18n) {
     items: items.toMap()
       .map(item => ({ ...item, type: item.itemType }))
       .map(item => omit(item, ['id', 'itemType', 'createdAt', 'updatedAt']))
+      .map(transformItem)
   }))
   const seo = page.seo.toMap()
   const slugI18n = locales.reduce((out, locale) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,6 +2632,45 @@
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
       "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
     },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "dev": true,
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        }
+      }
+    },
     "chokidar": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
@@ -8313,6 +8352,15 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "parseurl": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/vue": "^3.4.7",
     "ajv": "^6.5.1",
     "babel-eslint": "^8.2.1",
+    "cheerio": "^1.0.0-rc.2",
     "eslint": "^4.15.0",
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^1.7.1",


### PR DESCRIPTION
This prevents images being displayed in large original formats, which consume bandwidth. Instead, image components should be used.