### PR TITLE
Fix URLs of generated pages

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -22,7 +22,7 @@ module.exports = {
       '/',
       Object.keys(pages).map(key => {
         const slugI18n = pages[key]
-        return Object.keys(slugI18n).map(locale => `/${locale}/${slugI18n[locale]}`)
+        return Object.keys(slugI18n).map(locale => `/${locale}/${slugI18n[locale]}/`)
       })
     ])
   },


### PR DESCRIPTION
Before the generated index.html files only contained redirects to the correct pages. Which means without JavaScript the pages were still blank. Now the correct pages are generated and they have proper HTML.