### PR TITLE
Only enable Google Analytics if Tracking ID is set

### DIFF
--- a/config/nuxt/modules.js
+++ b/config/nuxt/modules.js
@@ -7,6 +7,6 @@ const nuxtI18n = require('./modules/nuxt-i18n')
 module.exports = [
   '@nuxtjs/proxy',
   '@nuxtjs/sitemap',
-  ['@nuxtjs/google-analytics', googleAnalytics],
-  ['nuxt-i18n', nuxtI18n],
+  googleAnalytics,
+  nuxtI18n,
 ]

--- a/config/nuxt/modules/google-analytics.js
+++ b/config/nuxt/modules/google-analytics.js
@@ -4,22 +4,25 @@ const isProduction = (process.env.NODE_ENV === 'production')
 /**
  * https://github.com/nuxt-community/analytics-module
  */
-module.exports = {
-  id: appConfig.googleAnalyticsTrackingId,
-  /**
-   * Debug while in development mode
-   * @see https://matteogabriele.gitbooks.io/vue-analytics/content/docs/debug.html
-   */
-  debug: {
-    enabled: !isProduction,
-    sendHitTask: isProduction,
-  },
-  /**
-   * Anonymize tracking
-   * @see https://www.themarketingtechnologist.co/setting-up-a-cookie-law-compliant-google-analytics-tracker/
-   */
-  set: [
-    { field: 'displayFeaturesTask', value: null },
-    { field: 'anonymizeIp', value: true },
-  ],
-}
+module.exports = appConfig.googleAnalyticsTrackingId &&
+  ['@nuxtjs/google-analytics',
+  {
+    id: appConfig.googleAnalyticsTrackingId,
+    /**
+     * Debug while in development mode
+     * @see https://matteogabriele.gitbooks.io/vue-analytics/content/docs/debug.html
+     */
+    debug: {
+      enabled: !isProduction,
+      sendHitTask: isProduction,
+    },
+    /**
+     * Anonymize tracking
+     * @see https://www.themarketingtechnologist.co/setting-up-a-cookie-law-compliant-google-analytics-tracker/
+     */
+    set: [
+      { field: 'displayFeaturesTask', value: null },
+      { field: 'anonymizeIp', value: true },
+    ],
+  }
+]

--- a/config/nuxt/modules/nuxt-i18n.js
+++ b/config/nuxt/modules/nuxt-i18n.js
@@ -4,23 +4,26 @@ const defaultLocale = locales[0]
 /**
  * @see https://nuxt-community.github.io/nuxt-i18n/
  */
-module.exports = {
-  defaultLocale,
-  detectBrowserLanguage: {
-    useCookie: true,
-    cookieKey: 'i18n_redirected'
-  },
-  lazy: true,
-  langDir: 'static/data/',
-  locales: locales.map(locale => ({
-    code: locale,
-    file: `${locale}/messages.json`,
-    iso: locale,
-    name: locale,
-  })),
-  rootRedirect: defaultLocale,
-  strategy: 'prefix',
-  vueI18n: {
-    fallbackLocale: defaultLocale,
+module.exports =[
+  'nuxt-i18n',
+  {
+    defaultLocale,
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieKey: 'i18n_redirected'
+    },
+    lazy: true,
+    langDir: 'static/data/',
+    locales: locales.map(locale => ({
+      code: locale,
+      file: `${locale}/messages.json`,
+      iso: locale,
+      name: locale,
+    })),
+    rootRedirect: defaultLocale,
+    strategy: 'prefix',
+    vueI18n: {
+      fallbackLocale: defaultLocale,
+    }
   }
-}
+]

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -66,7 +66,12 @@ module.exports = {
 
   modules: [
     '@nuxtjs/proxy',
-    ['@nuxtjs/google-analytics', { // https://github.com/nuxt-community/analytics-module
+    /**
+     * Add Google Analytics module,
+     * but only if `appConfig.googleAnalyticsTrackingId` is set.
+     * @see https://github.com/nuxt-community/analytics-module
+     */
+    appConfig.googleAnalyticsTrackingId && ['@nuxtjs/google-analytics', {
       id: appConfig.googleAnalyticsTrackingId,
       /**
        * Debug while in development mode
@@ -106,7 +111,8 @@ module.exports = {
       }
     }],
     '@nuxtjs/sitemap'
-  ],
+  ].filter(Boolean),
+
   sitemap: {
     generate: true,
     hostname: baseUrl,


### PR DESCRIPTION
Resolves [Trello issue 66: only load Google Analytics when configured](https://trello.com/c/31Geiba6/66-only-load-google-analytics-when-configured).