### PR TITLE
Fix switch language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8069,6 +8069,7 @@
       "requires": {
         "@nuxtjs/youch": "^4.2.3",
         "ansi-html": "^0.0.7",
+        "autoprefixer": "^7.2.5",
         "babel-core": "^6.26.0",
         "babel-loader": "^7.1.2",
         "babel-preset-vue-app": "^2.0.0",
@@ -8128,6 +8129,21 @@
         "webpack-dev-middleware": "^2.0.5",
         "webpack-hot-middleware": "^2.21.0",
         "webpack-node-externals": "^1.6.0"
+      },
+      "dependencies": {
+        "autoprefixer": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+          "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+          "requires": {
+            "browserslist": "^2.11.3",
+            "caniuse-lite": "^1.0.30000805",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^6.0.17",
+            "postcss-value-parser": "^3.2.3"
+          }
+        }
       }
     },
     "nuxt-i18n": {
@@ -9183,6 +9199,7 @@
       "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz",
       "integrity": "sha512-awPDhI4OKetcHCr560iVCoDuP6e/vn0r6EAqdWPpAavJMvkBSZ6kDpSN4b3mB3Ti57hQMunHHM8Wvx9PeuYXtA==",
       "requires": {
+        "autoprefixer": "^7.1.1",
         "caniuse-api": "^2.0.0",
         "chalk": "^2.0.1",
         "pixrem": "^4.0.0",
@@ -9215,6 +9232,19 @@
         "postcss-selector-not": "^3.0.1"
       },
       "dependencies": {
+        "autoprefixer": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+          "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+          "requires": {
+            "browserslist": "^2.11.3",
+            "caniuse-lite": "^1.0.30000805",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^6.0.17",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
         "caniuse-api": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",

--- a/src/client/components/language-selector/language-selector.stories.js
+++ b/src/client/components/language-selector/language-selector.stories.js
@@ -1,19 +1,9 @@
 import VueI18n from 'vue-i18n'
+import Vuex from 'vuex'
 import { storiesOf } from '@storybook/vue'
 import { withReadme } from 'storybook-readme'
 import readme from './readme.md'
 import LanguageSelector from './'
-
-export const i18n = () => {
-  return new VueI18n({
-    locale: 'en',
-    messages: {
-      en: {
-        skip_to_content: 'Skip to content',
-      }
-    },
-  })
-}
 
 export const mockLocales = (locales) => {
   return locales.map(locale => ({
@@ -44,5 +34,13 @@ storiesOf('Language selector', module)
           moreThanTwoLocales: mockLocales(['en', 'nl', 'pt', 'fr', 'it'])
         }
       },
-      i18n: i18n()
+      i18n: new VueI18n({
+        locale: 'en',
+        messages: {
+          en: {
+            select_language: 'Select language',
+          }
+        },
+      }),
+      store: new Vuex.Store(),
   }))

--- a/src/client/components/language-selector/language-selector.vue
+++ b/src/client/components/language-selector/language-selector.vue
@@ -17,24 +17,22 @@
     class="language-selector__list"
     :class="{'language-selector__list--open': isOpen}"
   >
-    <li class="language-selector__item" v-for="locale in locales" :key="locale.code">
-      <nuxt-link
-        v-if="isSlugRoute && shouldIncludeLocale(locale.code)"
-        class="language-selector__link"
-        rel="alternate"
-        :hreflang="locale.code"
-        :to="localeUrl({ name: 'slug', params: { slug: slugI18n[locale.code] } }, locale.code)">
-        {{ locale.name }}
-      </nuxt-link>
-      <nuxt-link
-        v-else-if="shouldIncludeLocale(locale.code)"
-        class="language-selector__link"
-        rel="alternate"
-        :hreflang="locale.code"
-        :to="switchLocaleUrl(locale.code)">
-        {{ locale.name }}
-      </nuxt-link>
-    </li>
+    <template v-for="locale in locales">
+      <li
+        v-if="shouldIncludeLocale(locale.code)"
+        :key="locale.code"
+        class="language-selector__item"
+      >
+        <nuxt-link
+          class="language-selector__link"
+          rel="alternate"
+          :hreflang="locale.code"
+          :to="pageUrl(locale.code)"
+        >
+          {{ locale.name }}
+        </nuxt-link>
+      </li>
+    </template>
   </ul>
 </div>
 </template>
@@ -44,24 +42,31 @@ export default {
   props: ['locales'],
   data() {
     return {
-      currentLocale: 'en',
-      isOpen: false
+      isOpen: false,
     }
   },
   computed: {
+    currentLocale () { return this.$i18n.locale },
     useDropdown () { return this.locales.length > 2 },
-    isSlugRoute () { return this.$route.name === `slug${this.$i18n.routesNameSeparator}${this.currentLocale}` },
+    isSlugRoute () { return this.$route.name === this.slugRouteName },
     slugI18n () { return this.$store.state.slugI18n },
-
+    slugRouteName () { return `slug${this.$i18n.routesNameSeparator}${this.currentLocale}` },
   },
   methods: {
-    toggleList () {
-      this.isOpen = !this.isOpen
+    pageUrl (locale) {
+      const { isSlugRoute, localeUrl, slugI18n, switchLocaleUrl } = this
+      if (isSlugRoute) {
+        return localeUrl({ name: 'slug', params: { slug: slugI18n[locale] } }, locale)
+      } else {
+        return switchLocaleUrl(locale)
+      }
     },
     shouldIncludeLocale (locale) {
       // Exclude current locale from dropdown
-      return (this.useDropdown && locale !== this.currentLocale)
-        || !this.useDropdown // Always show in normal list
+      return (!this.useDropdown || locale !== this.currentLocale)
+    },
+    toggleList () {
+      this.isOpen = !this.isOpen
     },
   }
 }
@@ -76,7 +81,7 @@ export default {
 }
 .language-selector__open {
   display: none;
-  padding: var(--spacing-half)
+  padding: var(--spacing-half);
 }
 .language-selector__open::after {
   content: '▼';

--- a/src/client/store/index.js
+++ b/src/client/store/index.js
@@ -3,10 +3,7 @@ import Vuex from 'vuex'
 const createStore = () => {
   return new Vuex.Store({
     state: {
-      slugI18n: {
-        en: 'about-us',
-        nl: 'over-ons',
-      },
+      slugI18n: {},
     },
     mutations: {
       setSlugI18n (state, slugI18n) {


### PR DESCRIPTION
Resolves [Trello issue 76: fix language switch slug bug](https://trello.com/c/x6iALS1I/76-fix-language-switch-slug-bug)

**Before**:
Select **EN** on https://leanwebkit.voorhoede.nl/nl/handleidingen/ navigates to non existing https://leanwebkit.voorhoede.nl/en/handleidingen/

**After**:
Select **EN** on https://deploy-preview-66--leanwebkit.netlify.com/nl/handleidingen/ navigates to  https://deploy-preview-66--leanwebkit.netlify.com/en/guides/