### PR TITLE
Filter out undefined/unused Nuxt modules

### DIFF
--- a/config/nuxt/modules.js
+++ b/config/nuxt/modules.js
@@ -11,4 +11,4 @@ module.exports = [
   googleAnalytics,
   nuxtI18n,
   nuxtPwa,
-]
+].filter(Boolean)


### PR DESCRIPTION
Content editors can opt out of modules in the CMS. This change prevents the app from breaking.

Resolves [Trello issue : Make adding a Google Analytics id in Dato not mandatory](https://trello.com/c/mHfI4JFQ/89-make-adding-a-google-analytics-id-in-dato-not-mandatory)