### PR TITLE
fix(get-page-data): use readFile instead of readFileSync

### DIFF
--- a/src/client/lib/get-page-data.js
+++ b/src/client/lib/get-page-data.js
@@ -1,12 +1,16 @@
+
 export default function ({ locale, slug }) {
   const url = `/data/${locale}/pages/${slug}.json`
-  
+
   if (process.client) {
     // On client load over http
     return fetch(url).then(res => res.json())
   } else {
     // On server load from file system
-    const data = JSON.parse(require('fs').readFileSync(`src/client/static${url}`, 'utf8'))
-    return Promise.resolve(data)
+    return new Promise((resolve, reject) => {
+      require('fs').readFile(`src/client/static${url}`, 'utf8', (err, data) => {
+        err ? reject(err) : resolve( JSON.parse(data) );
+      });
+    });
   }
 }


### PR DESCRIPTION
It's advised to not use synchronous "blocking" calls on the server (see: https://nodejs.org/en/docs/guides/blocking-vs-non-blocking/ for more info)