### PR TITLE
feat: add site name to the page title

### DIFF
--- a/src/client/lib/seo-head.js
+++ b/src/client/lib/seo-head.js
@@ -6,15 +6,18 @@
  *
  * @param {Object} seo
  * @param {String} seo.title
+ * @param {String} seo.titleTemplate
  * @param {String} seo.description
  * @param {Object} [seo.image]
  * @param {String} [seo.image.url]
  * @param {Number} [seo.image.width]
  * @param {Number} [seo.image.height]
+ * @param {String} seo.url
  */
-export default function seoHead ({ title, description, image, url }) {
+export default function seoHead ({ title, titleTemplate, description, image, url }) {
   return {
     title,
+    titleTemplate,
     link: [
       url && { rel: 'canonical', href: url },
     ].filter(Boolean), // only pass valid <link> objects to template

--- a/src/client/pages/_slug.vue
+++ b/src/client/pages/_slug.vue
@@ -16,6 +16,7 @@
 <script>
 import { LazyTracking, PageLayout, SocialShare } from '../components/'
 import { getPageData, seoHead } from '../lib/'
+import appConfig from '../static/data/app.json'
 
 export default {
   components: { LazyTracking, PageLayout, SocialShare },
@@ -28,7 +29,7 @@ export default {
   },
 
   head () {
-    return seoHead(this.page.seo)
+    return seoHead({ ...this.page.seo, titleTemplate: `%s | ${ appConfig.title }` })
   }
 }
 </script>


### PR DESCRIPTION
SEO: add site name to <title> for pages

* [Trello](https://trello.com/c/USAWhOm8/122-seo-add-site-name-to-title-for-pages)
* [Preview Page](https://deploy-preview-125--leanwebkit.netlify.com/)