### PR TITLE
fix: add isHome to page object so SmartLink can use correct object

### DIFF
--- a/dato.config.js
+++ b/dato.config.js
@@ -139,6 +139,7 @@ function formatLink (link) {
       title: title || page.title,
       slug: page.slug,
       theme,
+      isHome: page.entity.itemType.apiKey === 'home'
     }
   } else {
     return {

--- a/src/client/components/smart-link/smart-link.vue
+++ b/src/client/components/smart-link/smart-link.vue
@@ -1,5 +1,5 @@
 <template>
-  <nuxt-link :active-class="activeClass" v-if="item.type === 'page'" :to="localeUrl({ name: 'slug', params: { slug: item.slug } })" >
+  <nuxt-link :active-class="activeClass" v-if="item.type === 'page'" :to="localeUrl(namedRouteObject(item))" >
     {{ item.title }}
   </nuxt-link>
   <a v-else :href="item.url" data-outbound="true" target="_blank" rel="noopener">
@@ -17,7 +17,11 @@ export default {
           return false
         }
         if (item.type === 'page') {
-          return typeof item.slug === 'string'
+          if (item.isHome) {
+            return true
+          } else {
+            return typeof item.slug === 'string'
+          }
         } else {
           return typeof item.url === 'string'
         }
@@ -29,5 +33,17 @@ export default {
       default: '',
     }
   },
+  methods: {
+    namedRouteObject(item) {
+      return item.isHome
+        ? { name: 'index' }
+        : {
+          name: 'slug',
+          params: {
+            slug: item.slug
+          }
+        }
+    }
+  }
 }
 </script>


### PR DESCRIPTION
Since the Home page is not a `_slug` page, the `SmartLink` component throws errors. 
Now we can have a link to home without an error